### PR TITLE
Enable Bundler caching on Travis so that builds run faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: ruby
+
+cache: bundler
+
 rvm:
   - 2.2
 


### PR DESCRIPTION
...and remove duplicate dependency on rspec from the gemspec file so that 'rake build' works.
